### PR TITLE
Provides a mechanism to "lock" a source GH repo

### DIFF
--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -611,7 +611,7 @@ namespace OctoshiftCLI
             };
         }
 
-        public virtual async Task ArchiveRepository(string sourceOrg, string sourceRepo)
+        public virtual async Task<(bool successful, string message)> ArchiveRepository(string sourceOrg, string sourceRepo)
         {
             var repositoryId = await GetRepositoryId(sourceOrg, sourceRepo);
 
@@ -632,6 +632,17 @@ namespace OctoshiftCLI
 
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
+
+            var successful = true;
+            var message = string.Empty;
+
+            if (data.ContainsKey("errors") && data["errors"]!.HasValues)
+            {
+                successful = false;
+                message = data["errors"][0]!["message"]!.ToString();
+            }
+
+            return (successful, message);
         }
     }
 }

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -611,21 +611,21 @@ namespace OctoshiftCLI
             };
         }
 
-        public virtual async Task LockSourceRepoViaSettingArchiveState(string sourceOrg, string sourceRepo)
+        public virtual async Task ArchiveRepository(string sourceOrg, string sourceRepo)
         {
-            var repoId = await GetRepositoryId(sourceOrg, sourceRepo);
+            var repositoryId = await GetRepositoryId(sourceOrg, sourceRepo);
 
             var url = $"{_apiUrl}/graphql";
 
-            var query = "mutation archiveRepository($repositoryId: ID!)";
-            var gql = "archiveRepository(input: {repositoryId: $repoId}) { clientMutationId } }";
+            var query = "mutation archiveRepository($repoId: ID!)";
+            var gql = "archiveRepository(input: {repositoryId: $repoId}) { clientMutationId }";
 
             var payload = new
             {
                 query = $"{query} {{ {gql} }}",
                 variables = new
                 {
-                    repositoryId = repoId
+                    repoId = repositoryId
                 },
                 operationName = "archiveRepository"
             };

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -143,6 +143,23 @@ namespace OctoshiftCLI
             return (string)data["data"]["organization"]["id"];
         }
 
+        public virtual async Task<string> GetRepositoryId(string org, string repo)
+        {
+            var url = $"{_apiUrl}/graphql";
+
+            var payload = new
+            {
+                // TODO: this is super ugly, need to find a graphql library to make this code nicer
+                query = "query repository($owner: String!, $name: String!) { repository(name: $name, owner: $owner) { id } }",
+                variables = new { owner = org, name = repo }
+            };
+
+            var response = await _client.PostAsync(url, payload);
+            var data = JObject.Parse(response);
+
+            return (string)data["data"]["repository"]["id"];
+        }
+
         public virtual async Task<string> CreateAdoMigrationSource(string orgId, string adoServerUrl)
         {
             var url = $"{_apiUrl}/graphql";
@@ -430,13 +447,14 @@ namespace OctoshiftCLI
             await _client.DeleteAsync(url);
         }
 
-        public virtual async Task<int> StartGitArchiveGeneration(string org, string repo)
+        public virtual async Task<int> StartGitArchiveGeneration(string org, string repo, bool lockRepo)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations";
 
             var options = new
             {
                 repositories = new[] { repo },
+                lock_repositories = lockRepo,
                 exclude_metadata = true
             };
 
@@ -445,13 +463,14 @@ namespace OctoshiftCLI
             return (int)data["id"];
         }
 
-        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo)
+        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo, bool lockRepo)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations";
 
             var options = new
             {
                 repositories = new[] { repo },
+                lock_repositories = lockRepo,
                 exclude_git_data = true,
                 exclude_releases = true,
                 exclude_owner_projects = true
@@ -590,6 +609,29 @@ namespace OctoshiftCLI
                                     }
                                     : null
             };
+        }
+
+        public virtual async Task LockSourceRepoViaSettingArchiveState(string sourceOrg, string sourceRepo)
+        {
+            var repoId = await GetRepositoryId(sourceOrg, sourceRepo);
+
+            var url = $"{_apiUrl}/graphql";
+
+            var query = "mutation archiveRepository($repositoryId: ID!)";
+            var gql = "archiveRepository(input: {repositoryId: $repoId}) { clientMutationId } }";
+
+            var payload = new
+            {
+                query = $"{query} {{ {gql} }}",
+                variables = new
+                {
+                    repositoryId = repoId
+                },
+                operationName = "archiveRepository"
+            };
+
+            var response = await _client.PostAsync(url, payload);
+            var data = JObject.Parse(response);
         }
     }
 }

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -25,7 +25,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
             command.Should().NotBeNull();
             command.Name.Should().Be("generate-script");
-            command.Options.Count.Should().Be(15);
+            command.Options.Count.Should().Be(16);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-server-url", false, true);
@@ -42,6 +42,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "github-source-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+            TestHelpers.VerifyCommandOption(command.Options, "archive-gh-repos", false);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -50,7 +50,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
-            TestHelpers.VerifyCommandOption(command.Options, "lock-repo", false);
+            TestHelpers.VerifyCommandOption(command.Options, "archive-gh-repo", false);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -28,7 +28,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var command = new MigrateRepoCommand(null, null, null, null, null);
             command.Should().NotBeNull();
             command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(20);
+            command.Options.Count.Should().Be(21);
 
             TestHelpers.VerifyCommandOption(command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-server-url", false, true);
@@ -50,6 +50,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
+            TestHelpers.VerifyCommandOption(command.Options, "lock-repo", false);
         }
 
         [Fact]
@@ -361,8 +362,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(gitArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
@@ -628,8 +629,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(gitArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
@@ -709,8 +710,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(gitArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
@@ -761,8 +762,8 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var metadataArchiveId = 2;
 
             var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(gitArchiveId);
+            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
             mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Failed);
 
             var mockAzureApi = TestHelpers.CreateMock<AzureApi>();

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -217,7 +217,13 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 _log.LogInformation($"Locking source repo '{sourceRepoUrl}'...");
                 var sourceGitHubApi = _sourceGithubApiFactory.Create(sourcePersonalAccessToken: args.GithubSourcePat);
-                await sourceGitHubApi.ArchiveRepository(args.GithubSourceOrg, args.SourceRepo);
+                var (successful, message) = await sourceGitHubApi.ArchiveRepository(args.GithubSourceOrg, args.SourceRepo);
+
+                if (!successful)
+                {
+                    _log.LogError($"Unable to put the {args.SourceRepo} into an archive state. Reason: {message}");
+                    return;
+                }
             }
 
             var migrationId = await githubApi.StartMigration(


### PR DESCRIPTION
<!--
For the checkboxes below you must check each one to indicate that you either did the relevant task, or considered it and decided there was nothing that needed doing
-->

- [ ] Did you write/update appropriate tests
- [ ] Release notes updated (if appropriate)
- [ ] Appropriate logging output
- [ ] Issue linked
- [ ] Docs updated (or issue created)

<!--
For docs we should review the docs at:
https://docs.github.com/en/early-access/github/migrating-with-github-enterprise-importer
and the README.md in this repo

If a doc update is required based on the changes in this PR, it is sufficient to create an issue and link to it here. The doc update can be made later/separately.

The process to update the docs can be found here:
https://github.com/github/docs-early-access#opening-prs

The markdown files are here: 
https://github.com/github/docs-early-access/tree/main/content/github/migrating-with-github-enterprise-importer
-->

By adding a flag called `archive-gh-repo` to the `migrate-repo` command and a flag called `archive-ge-repos` to the `generate-script` command, this provides a way to essentially "lock" the source repository.

This approach is needed for any migration from GitHub Cloud to EMU to ensure that data integrity is persisted while performing a migration. Putting a repo into an archive state is on the only __publicly__ available option to safely put the repo into some sort of read-only state.