### PR TITLE
Added Archive Repo Command

### DIFF
--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -486,14 +486,13 @@ namespace OctoshiftCLI
             await _client.DeleteAsync(url);
         }
 
-        public virtual async Task<int> StartGitArchiveGeneration(string org, string repo, bool lockRepo)
+        public virtual async Task<int> StartGitArchiveGeneration(string org, string repo)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations";
 
             var options = new
             {
                 repositories = new[] { repo },
-                lock_repositories = lockRepo,
                 exclude_metadata = true
             };
 
@@ -502,14 +501,13 @@ namespace OctoshiftCLI
             return (int)data["id"];
         }
 
-        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo, bool lockRepo)
+        public virtual async Task<int> StartMetadataArchiveGeneration(string org, string repo)
         {
             var url = $"{_apiUrl}/orgs/{org}/migrations";
 
             var options = new
             {
                 repositories = new[] { repo },
-                lock_repositories = lockRepo,
                 exclude_git_data = true,
                 exclude_releases = true,
                 exclude_owner_projects = true

--- a/src/Octoshift/GithubApi.cs
+++ b/src/Octoshift/GithubApi.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using Octoshift.Models;
@@ -172,7 +173,9 @@ namespace OctoshiftCLI
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
 
-            return (string)data["data"]["repository"]["id"];
+            CheckForErrors(data);
+
+            return (string)data["data"]!["repository"]!["id"];
         }
 
         public virtual async Task<string> CreateAdoMigrationSource(string orgId, string adoServerUrl)
@@ -648,7 +651,7 @@ namespace OctoshiftCLI
             };
         }
 
-        public virtual async Task<(bool successful, string message)> ArchiveRepository(string sourceOrg, string sourceRepo)
+        public virtual async Task ArchiveRepository(string sourceOrg, string sourceRepo)
         {
             var repositoryId = await GetRepositoryId(sourceOrg, sourceRepo);
 
@@ -670,16 +673,50 @@ namespace OctoshiftCLI
             var response = await _client.PostAsync(url, payload);
             var data = JObject.Parse(response);
 
-            var successful = true;
-            var message = string.Empty;
+            CheckForErrors(data);
+        }
 
-            if (data.ContainsKey("errors") && data["errors"]!.HasValues)
+        public virtual async Task<bool> IsRepoArchived(string org, string repo)
+        {
+            var url = $"{_apiUrl}/graphql";
+
+            var payload = new
             {
-                successful = false;
-                message = data["errors"][0]!["message"]!.ToString();
+                // TODO: this is super ugly, need to find a graphql library to make this code nicer
+                query = "query repository($owner: String!, $name: String!) { repository(name: $name, owner: $owner) { isArchived } }",
+                variables = new { owner = org, name = repo }
+            };
+
+            var response = await _client.PostAsync(url, payload);
+            var data = JObject.Parse(response);
+
+            CheckForErrors(data);
+
+            return (bool)data["data"]!["repository"]!["isArchived"];
+        }
+
+        protected void CheckForErrors(JObject responseJObject)
+        {
+            if (responseJObject == null || !responseJObject.ContainsKey("errors") || !responseJObject["errors"]!.HasValues)
+            {
+                return;
             }
 
-            return (successful, message);
+            var errorMessageStringBuilder = new StringBuilder();
+
+            foreach (var error in responseJObject["errors"])
+            {
+                var message = error["message"];
+
+                if (message == null)
+                {
+                    continue;
+                }
+
+                errorMessageStringBuilder.AppendLine(message.ToString());
+            }
+
+            throw new OctoshiftCliException(errorMessageStringBuilder.ToString());
         }
     }
 }

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -40,8 +40,8 @@ namespace OctoshiftCLI.IntegrationTests
         [Fact]
         public async Task ArchiveSourceGhecRepo()
         {
-            var githubSourceOrg = $"e2e-testing-source-{_helper.GetOsName()}";
-            var githubTargetOrg = $"e2e-testing-{_helper.GetOsName()}";
+            var githubSourceOrg = $"e2e-testing-source-{TestHelper.GetOsName()}";
+            var githubTargetOrg = $"e2e-testing-{TestHelper.GetOsName()}";
             var repo1 = "repo-1";
             var repo2 = "repo-2";
 
@@ -51,7 +51,7 @@ namespace OctoshiftCLI.IntegrationTests
             await _helper.CreateGithubRepo(githubSourceOrg, repo1);
             await _helper.CreateGithubRepo(githubSourceOrg, repo2);
 
-            await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --archive-source-gh-repos --download-migration-logs");
+            await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --archive-source-gh-repos --download-migration-logs", _tokens);
 
             await _helper.AssertGithubRepoExists(githubTargetOrg, repo1);
             await _helper.AssertGithubRepoExists(githubTargetOrg, repo2);

--- a/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
+++ b/src/OctoshiftCLI.IntegrationTests/GithubToGithub.cs
@@ -34,6 +34,38 @@ namespace OctoshiftCLI.IntegrationTests
         }
 
         [Fact]
+        public async Task ArchiveSourceGhecRepo()
+        {
+            var githubSourceOrg = $"e2e-testing-source-{_helper.GetOsName()}";
+            var githubTargetOrg = $"e2e-testing-{_helper.GetOsName()}";
+            var repo1 = "repo-1";
+            var repo2 = "repo-2";
+
+            await _helper.ResetGithubTestEnvironment(githubSourceOrg);
+            await _helper.ResetGithubTestEnvironment(githubTargetOrg);
+
+            await _helper.CreateGithubRepo(githubSourceOrg, repo1);
+            await _helper.CreateGithubRepo(githubSourceOrg, repo2);
+
+            await _helper.RunGeiCliMigration($"generate-script --github-source-org {githubSourceOrg} --github-target-org {githubTargetOrg} --archive-source-gh-repos --download-migration-logs");
+
+            await _helper.AssertGithubRepoExists(githubTargetOrg, repo1);
+            await _helper.AssertGithubRepoExists(githubTargetOrg, repo2);
+
+            await _helper.AssertGithubRepoInitialized(githubTargetOrg, repo1);
+            await _helper.AssertGithubRepoInitialized(githubTargetOrg, repo2);
+
+            _helper.AssertMigrationLogFileExists(githubTargetOrg, repo1);
+            _helper.AssertMigrationLogFileExists(githubTargetOrg, repo2);
+
+            // Doing this last ensures enough time has passed since
+            // the generate-script command started to allow for the
+            // archive repo API call to run and complete
+            await _helper.AssertGithubRepoIsArchived(githubSourceOrg, repo1);
+            await _helper.AssertGithubRepoIsArchived(githubSourceOrg, repo2);
+        }
+
+        [Fact]
         public async Task Basic()
         {
             var githubSourceOrg = $"e2e-testing-source-{_helper.GetOsName()}";

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -594,5 +594,14 @@ steps:
 
             File.Exists(migrationLogFile).Should().BeTrue();
         }
+
+        public async Task AssertGithubRepoIsArchived(string githubOrg, string repo)
+        {
+            _output.WriteLine("Checking that the repos in GitHub exist...");
+
+            var isRepoArchived = await _githubApi.IsRepoArchived(githubOrg, repo);
+
+            isRepoArchived.Should().BeTrue();
+        }
     }
 }

--- a/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
+++ b/src/OctoshiftCLI.IntegrationTests/TestHelper.cs
@@ -597,7 +597,7 @@ steps:
 
             isRepoArchived.Should().BeTrue();
         }
-      
+
         public async Task ResetBlobContainers()
         {
             _output.WriteLine($"Deleting all blob containers...");

--- a/src/OctoshiftCLI.Tests/gei/Commands/ArchiveGitHubRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/ArchiveGitHubRepoCommandTests.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Moq;
+using OctoshiftCLI.GithubEnterpriseImporter;
+using OctoshiftCLI.GithubEnterpriseImporter.Commands;
+using Xunit;
+
+// ReSharper disable once CheckNamespace
+namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands;
+
+public class ArchiveGitHubRepoCommandTests
+{
+    public ArchiveGitHubRepoCommandTests() =>
+        _command = new ArchiveGitHubRepoCommand(
+            _mockOctoLogger.Object,
+            _mockSourceGithubApiFactory.Object,
+            _mockEnvironmentVariableProvider.Object);
+
+    private readonly Mock<GithubApi> _mockGithubApi = TestHelpers.CreateMock<GithubApi>();
+    private readonly Mock<ISourceGithubApiFactory> _mockSourceGithubApiFactory = new();
+    private readonly Mock<EnvironmentVariableProvider> _mockEnvironmentVariableProvider = TestHelpers.CreateMock<EnvironmentVariableProvider>();
+    private readonly Mock<OctoLogger> _mockOctoLogger = TestHelpers.CreateMock<OctoLogger>();
+    private readonly ArchiveGitHubRepoCommand _command;
+
+    [Fact]
+    public async Task Happy_Path_For_Ghec()
+    {
+        var sourceOrg = Guid.NewGuid().ToString();
+        var sourceRepo = Guid.NewGuid().ToString();
+        var sourceGithubPat = Guid.NewGuid().ToString();
+
+        _mockGithubApi.Setup(_ => _.ArchiveRepository(sourceOrg, sourceRepo)).Verifiable("`ArchiveRepository` call did not match specifications");
+
+        _mockSourceGithubApiFactory
+            .Setup(_ => _.Create(null, sourceGithubPat))
+            .Returns(_mockGithubApi.Object);
+
+        var args = new ArchiveGitHubRepoCommandArgs
+        {
+            GithubSourceOrg = sourceOrg,
+            GithubSourcePat = sourceGithubPat,
+            SourceRepo = sourceRepo
+        };
+
+        await _command.Invoke(args);
+    }
+
+    [Fact]
+    public async Task Happy_Path_For_Ghes()
+    {
+        var ghesApiUrl = "https://myghes.local/api/v3";
+        var sourceOrg = Guid.NewGuid().ToString();
+        var sourceRepo = Guid.NewGuid().ToString();
+        var sourceGithubPat = Guid.NewGuid().ToString();
+
+        _mockGithubApi.Setup(_ => _.ArchiveRepository(sourceOrg, sourceRepo)).Verifiable("`ArchiveRepository` call did not match specifications");
+
+        _mockSourceGithubApiFactory
+            .Setup(_ => _.Create(ghesApiUrl, sourceGithubPat))
+            .Returns(_mockGithubApi.Object);
+
+        var args = new ArchiveGitHubRepoCommandArgs
+        {
+            GhesApiUrl = ghesApiUrl,
+            GithubSourceOrg = sourceOrg,
+            GithubSourcePat = sourceGithubPat,
+            SourceRepo = sourceRepo
+        };
+
+        await _command.Invoke(args);
+    }
+
+    [Fact]
+    public async Task Happy_Path_For_Ghes_With_No_Ssl_Verify()
+    {
+        var ghesApiUrl = "https://myghes.local/api/v3";
+        var sourceOrg = Guid.NewGuid().ToString();
+        var sourceRepo = Guid.NewGuid().ToString();
+        var sourceGithubPat = Guid.NewGuid().ToString();
+
+        _mockGithubApi.Setup(_ => _.ArchiveRepository(sourceOrg, sourceRepo)).Verifiable("`ArchiveRepository` call did not match specifications");
+
+        _mockSourceGithubApiFactory
+            .Setup(_ => _.CreateClientNoSsl(ghesApiUrl, sourceGithubPat))
+            .Returns(_mockGithubApi.Object);
+
+        var args = new ArchiveGitHubRepoCommandArgs
+        {
+            GhesApiUrl = ghesApiUrl,
+            GithubSourceOrg = sourceOrg,
+            GithubSourcePat = sourceGithubPat,
+            SourceRepo = sourceRepo,
+            NoSslVerify = true
+        };
+
+        await _command.Invoke(args);
+    }
+
+    [Fact]
+    public void Should_Have_Options()
+    {
+        _command.Should().NotBeNull();
+        _command.Name.Should().Be("archive-gh-repo");
+        _command.Options.Count.Should().Be(6);
+
+        TestHelpers.VerifyCommandOption(_command.Options, "github-source-org", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "github-source-pat", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "source-repo", true);
+        TestHelpers.VerifyCommandOption(_command.Options, "ghes-api-url", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "no-ssl-verify", false);
+        TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
+    }
+}

--- a/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/GenerateScriptCommandTests.cs
@@ -52,7 +52,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             _command.Should().NotBeNull();
             _command.Name.Should().Be("generate-script");
-            _command.Options.Count.Should().Be(16);
+            _command.Options.Count.Should().Be(17);
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-server-url", false, true);
@@ -70,6 +70,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(_command.Options, "github-source-pat", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "archive-source-gh-repos", false);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -69,7 +69,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
-            TestHelpers.VerifyCommandOption(command.Options, "archive-gh-repo", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "archive-gh-repo", false);
         }
 
         [Fact]

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -44,7 +44,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
 
         [Fact]
         public void Should_Have_Options()
-        {          
+        {
             _command.Should().NotBeNull();
             _command.Name.Should().Be("migrate-repo");
             _command.Options.Count.Should().Be(21);

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -45,32 +45,30 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         [Fact]
         public void Should_Have_Options()
         {
-            var command = new MigrateRepoCommand(null, null, null, null, null);
-            command.Should().NotBeNull();
-            command.Name.Should().Be("migrate-repo");
-            command.Options.Count.Should().Be(21);
+            _command.Should().NotBeNull();
+            _command.Name.Should().Be("migrate-repo");
+            _command.Options.Count.Should().Be(20);
 
-            TestHelpers.VerifyCommandOption(command.Options, "github-source-org", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ado-server-url", false, true);
-            TestHelpers.VerifyCommandOption(command.Options, "ado-source-org", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ado-team-project", false);
-            TestHelpers.VerifyCommandOption(command.Options, "source-repo", true);
-            TestHelpers.VerifyCommandOption(command.Options, "github-target-org", true);
-            TestHelpers.VerifyCommandOption(command.Options, "target-repo", false);
-            TestHelpers.VerifyCommandOption(command.Options, "target-api-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ghes-api-url", false);
-            TestHelpers.VerifyCommandOption(command.Options, "azure-storage-connection-string", false);
-            TestHelpers.VerifyCommandOption(command.Options, "no-ssl-verify", false);
-            TestHelpers.VerifyCommandOption(command.Options, "skip-releases", false, true);
-            TestHelpers.VerifyCommandOption(command.Options, "git-archive-url", false, true);
-            TestHelpers.VerifyCommandOption(command.Options, "metadata-archive-url", false, true);
-            TestHelpers.VerifyCommandOption(command.Options, "ssh", false, true);
-            TestHelpers.VerifyCommandOption(command.Options, "wait", false);
-            TestHelpers.VerifyCommandOption(command.Options, "github-source-pat", false);
-            TestHelpers.VerifyCommandOption(command.Options, "github-target-pat", false);
-            TestHelpers.VerifyCommandOption(command.Options, "ado-pat", false);
-            TestHelpers.VerifyCommandOption(command.Options, "verbose", false);
-            TestHelpers.VerifyCommandOption(command.Options, "archive-gh-repo", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "github-source-org", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-server-url", false, true);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-source-org", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-team-project", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "source-repo", true);
+            TestHelpers.VerifyCommandOption(_command.Options, "github-target-org", true);
+            TestHelpers.VerifyCommandOption(_command.Options, "target-repo", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "target-api-url", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ghes-api-url", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "azure-storage-connection-string", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "no-ssl-verify", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "skip-releases", false, true);
+            TestHelpers.VerifyCommandOption(_command.Options, "git-archive-url", false, true);
+            TestHelpers.VerifyCommandOption(_command.Options, "metadata-archive-url", false, true);
+            TestHelpers.VerifyCommandOption(_command.Options, "ssh", false, true);
+            TestHelpers.VerifyCommandOption(_command.Options, "wait", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "github-source-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
+            TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
         }
 
         [Fact]
@@ -357,14 +355,12 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                 .Returns(migrationId);
             _mockGithubApi.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
-            var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+            _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
+            _mockGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
+            _mockGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
 
             _mockAzureApi.Setup(x => x.DownloadArchive(gitArchiveUrl).Result).Returns(gitArchiveContent);
             _mockAzureApi.Setup(x => x.DownloadArchive(metadataArchiveUrl).Result).Returns(metadataArchiveContent);
@@ -605,16 +601,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     authenticatedMetadataArchiveUrl.ToString(),
                     false).Result)
                 .Returns(migrationId);
-
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
-
-            var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+            _mockGithubApi.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
             _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
@@ -686,16 +673,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
                     authenticatedMetadataArchiveUrl.ToString(),
                     false).Result)
                 .Returns(migrationId);
-
-            mockGithub.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
-
-            var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, metadataArchiveId).Result).Returns(ArchiveMigrationStatus.Exported);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, gitArchiveId).Result).Returns(gitArchiveUrl);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationUrl(SOURCE_ORG, metadataArchiveId).Result).Returns(metadataArchiveUrl);
+            _mockGithubApi.Setup(x => x.GetMigrationState(migrationId).Result).Returns("SUCCEEDED");
 
             _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
             _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
@@ -741,10 +719,9 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             var gitArchiveId = 1;
             var metadataArchiveId = 2;
 
-            var mockGhesGithubApi = TestHelpers.CreateMock<GithubApi>();
-            mockGhesGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(gitArchiveId);
-            mockGhesGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO, false).Result).Returns(metadataArchiveId);
-            mockGhesGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Failed);
+            _mockGithubApi.Setup(x => x.StartGitArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(gitArchiveId);
+            _mockGithubApi.Setup(x => x.StartMetadataArchiveGeneration(SOURCE_ORG, SOURCE_REPO).Result).Returns(metadataArchiveId);
+            _mockGithubApi.Setup(x => x.GetArchiveMigrationStatus(SOURCE_ORG, gitArchiveId).Result).Returns(ArchiveMigrationStatus.Failed);
 
             _mockSourceGithubApiFactory.Setup(m => m.Create(GHES_API_URL, It.IsAny<string>())).Returns(_mockGithubApi.Object);
             _mockAzureApiFactory.Setup(m => m.Create(AZURE_CONNECTION_STRING)).Returns(_mockAzureApi.Object);

--- a/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
+++ b/src/OctoshiftCLI.Tests/gei/Commands/MigrateRepoCommandTests.cs
@@ -47,7 +47,7 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
         {
             _command.Should().NotBeNull();
             _command.Name.Should().Be("migrate-repo");
-            _command.Options.Count.Should().Be(21);
+            _command.Options.Count.Should().Be(20);
 
             TestHelpers.VerifyCommandOption(_command.Options, "github-source-org", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-server-url", false, true);
@@ -69,7 +69,6 @@ namespace OctoshiftCLI.Tests.GithubEnterpriseImporter.Commands
             TestHelpers.VerifyCommandOption(_command.Options, "github-target-pat", false);
             TestHelpers.VerifyCommandOption(_command.Options, "ado-pat", false);
             TestHelpers.VerifyCommandOption(_command.Options, "verbose", false);
-            TestHelpers.VerifyCommandOption(_command.Options, "archive-gh-repo", false);
         }
 
         [Fact]

--- a/src/gei/Commands/ArchiveGitHubRepoCommand.cs
+++ b/src/gei/Commands/ArchiveGitHubRepoCommand.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.CommandLine;
+using System.CommandLine.Invocation;
+using System.Threading.Tasks;
+using OctoshiftCLI.Extensions;
+
+namespace OctoshiftCLI.GithubEnterpriseImporter.Commands;
+
+public class ArchiveGitHubRepoCommand : Command
+{
+    private readonly EnvironmentVariableProvider _environmentVariableProvider;
+    private readonly OctoLogger _log;
+    private readonly ISourceGithubApiFactory _sourceGithubApiFactory;
+
+    public ArchiveGitHubRepoCommand(OctoLogger log, ISourceGithubApiFactory sourceGithubApiFactory,
+        EnvironmentVariableProvider environmentVariableProvider) : base("archive-gh-repo")
+    {
+        _log = log;
+        _sourceGithubApiFactory = sourceGithubApiFactory;
+        _environmentVariableProvider = environmentVariableProvider;
+
+        Description = "Invokes the GitHub APIs to migrate the repo and all repo data.";
+
+        var githubSourceOrg = new Option<string>("--github-source-org")
+        {
+            IsRequired = true,
+            Description = "Uses GH_SOURCE_PAT env variable or --github-source-pat option. Will fall back to GH_PAT or --github-target-pat if not set."
+        };
+
+        var githubSourcePat = new Option<string>("--github-source-pat")
+        {
+            IsRequired = false,
+            Description = "PAT used to connect to the source repo. If not provided, will default to use GH_SOURCE_PAT env variable."
+        };
+
+        var sourceRepo = new Option<string>("--source-repo") { IsRequired = true };
+
+        var ghesApiUrl = new Option<string>("--ghes-api-url")
+        {
+            IsRequired = false,
+            Description = "Required if migrating from GHES. The API endpoint for your GHES instance. For example: http(s)://ghes.contoso.com/api/v3"
+        };
+
+        var noSslVerify = new Option("--no-ssl-verify")
+        {
+            IsRequired = false,
+            Description =
+                "Only effective if migrating from GHES. Disables SSL verification when communicating with your GHES instance. All other migration steps will continue to verify SSL. If your GHES instance has a self-signed SSL certificate then setting this flag will allow data to be extracted."
+        };
+
+        var verbose = new Option("--verbose") { IsRequired = false };
+
+        AddOption(githubSourceOrg);
+        AddOption(sourceRepo);
+        AddOption(githubSourcePat);
+        AddOption(ghesApiUrl);
+        AddOption(noSslVerify);
+        AddOption(verbose);
+
+        Handler = CommandHandler.Create<ArchiveGitHubRepoCommandArgs>(Invoke);
+    }
+
+    public async Task Invoke(ArchiveGitHubRepoCommandArgs args)
+    {
+        if (args is null)
+        {
+            throw new ArgumentNullException(nameof(args));
+        }
+
+        _log.Verbose = args.Verbose;
+
+        var sourceToken = args.GithubSourcePat ?? _environmentVariableProvider.SourceGithubPersonalAccessToken();
+
+        var githubApi = args.NoSslVerify
+            ? _sourceGithubApiFactory.CreateClientNoSsl(args.GhesApiUrl, sourceToken)
+            : _sourceGithubApiFactory.Create(args.GhesApiUrl, sourceToken);
+
+        if (args.GhesApiUrl.HasValue())
+        {
+            _log.LogInformation($"GHES API URL: {args.GhesApiUrl}");
+            _log.LogVerbose($"Ignore SSL: {args.NoSslVerify}");
+        }
+
+        _log.LogInformation($"Archiving the repository '{args.GithubSourceOrg}/{args.SourceRepo}'");
+
+        await githubApi.ArchiveRepository(args.GithubSourceOrg, args.SourceRepo);
+    }
+}
+
+public class ArchiveGitHubRepoCommandArgs
+{
+    public string GhesApiUrl { get; set; }
+    public string GithubSourceOrg { get; set; }
+    public string GithubSourcePat { get; set; }
+    public bool NoSslVerify { get; set; }
+    public string SourceRepo { get; set; }
+    public bool Verbose { get; set; }
+}

--- a/src/gei/Commands/GenerateScriptCommand.cs
+++ b/src/gei/Commands/GenerateScriptCommand.cs
@@ -61,11 +61,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             {
                 IsRequired = true
             };
-            var archiveGhRepos = new Option("--archive-gh-repos")
-            {
-                IsRequired = false,
-                Description = "Only effective if migrating from GitHub Cloud. This will place the source repository into an archive state to prevent changes while the migration is taking place."
-            };
 
             // GHES migration path
             var ghesApiUrl = new Option<string>("--ghes-api-url")
@@ -128,7 +123,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(adoSourceOrgOption);
             AddOption(adoTeamProject);
             AddOption(githubTargetOrgOption);
-            AddOption(archiveGhRepos);
 
             AddOption(ghesApiUrl);
             AddOption(azureStorageConnectionString);
@@ -363,7 +357,7 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             // Queuing migrations
             foreach (var repo in repos)
             {
-                content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, azureStorageConnectionString, noSslVerify, false, skipReleases, archiveRepos))}");
+                content.AppendLine($"$MigrationID = {ExecAndGetMigrationId(MigrateGithubRepoScript(githubSourceOrg, githubTargetOrg, repo, ghesApiUrl, azureStorageConnectionString, noSslVerify, false, skipReleases))}");
                 content.AppendLine($"$RepoMigrations[\"{repo}\"] = $MigrationID");
                 content.AppendLine();
             }
@@ -550,7 +544,7 @@ if ($Failed -ne 0) {
 
         private string GetGithubRepoName(string adoTeamProject, string repo) => $"{adoTeamProject}-{repo.Replace(" ", "-")}";
 
-        private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool wait, bool skipReleases, bool archiveRepo)
+        private string MigrateGithubRepoScript(string githubSourceOrg, string githubTargetOrg, string repo, string ghesApiUrl, string azureStorageConnectionString, bool noSslVerify, bool wait, bool skipReleases)
         {
             var ghesRepoOptions = "";
             if (ghesApiUrl.HasValue())
@@ -558,7 +552,7 @@ if ($Failed -ne 0) {
                 ghesRepoOptions = GetGhesRepoOptions(ghesApiUrl, azureStorageConnectionString, noSslVerify);
             }
 
-            return $"gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? " --wait" : string.Empty)}{(skipReleases ? " --skip-releases" : string.Empty)}{(archiveRepo ? " --archive-gh-repo" : string.Empty)}";
+            return $"gh gei migrate-repo --github-source-org \"{githubSourceOrg}\" --source-repo \"{repo}\" --github-target-org \"{githubTargetOrg}\" --target-repo \"{repo}\"{(!string.IsNullOrEmpty(ghesRepoOptions) ? $" {ghesRepoOptions}" : string.Empty)}{(_log.Verbose ? " --verbose" : string.Empty)}{(wait ? " --wait" : string.Empty)}{(skipReleases ? " --skip-releases" : string.Empty)}";
         }
 
         private string MigrateAdoRepoScript(string adoServerUrl, string adoSourceOrg, string teamProject, string adoRepo, string githubTargetOrg, string githubRepo, bool wait)
@@ -631,6 +625,5 @@ function ExecAndGetMigrationID {
         public string GithubSourcePat { get; set; }
         public string AdoPat { get; set; }
         public bool Verbose { get; set; }
-        public bool ArchiveGhRepos { get; set; }
     }
 }

--- a/src/gei/Commands/MigrateRepoCommand.cs
+++ b/src/gei/Commands/MigrateRepoCommand.cs
@@ -134,12 +134,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                 IsRequired = false
             };
 
-            var archiveGhRepo = new Option("--archive-gh-repo")
-            {
-                IsRequired = false,
-                Description = "Only effective if migrating from GitHub Cloud. This will place the source repository into an archive state to prevent changes while the migration is taking place."
-            };
-
             AddOption(githubSourceOrg);
             AddOption(adoServerUrl);
             AddOption(adoSourceOrg);
@@ -165,8 +159,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             AddOption(adoPat);
             AddOption(verbose);
 
-            AddOption(archiveGhRepo);
-
             Handler = CommandHandler.Create<MigrateRepoCommandArgs>(Invoke);
         }
 
@@ -189,7 +181,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
                   args.SourceRepo,
                   args.AzureStorageConnectionString,
                   args.GithubSourcePat,
-                  args.ArchiveGhRepo,
                   args.NoSslVerify
                 );
 
@@ -211,19 +202,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var migrationSourceId = args.GithubSourceOrg.HasValue()
                 ? await githubApi.CreateGhecMigrationSource(githubOrgId)
                 : await githubApi.CreateAdoMigrationSource(githubOrgId, args.AdoServerUrl);
-
-            if (!args.GhesApiUrl.HasValue() && args.GithubSourceOrg.HasValue() && args.ArchiveGhRepo)
-            {
-                _log.LogInformation($"Locking source repo '{sourceRepoUrl}'...");
-                var sourceGitHubApi = _sourceGithubApiFactory.Create(sourcePersonalAccessToken: args.GithubSourcePat);
-                var (successful, message) = await sourceGitHubApi.ArchiveRepository(args.GithubSourceOrg, args.SourceRepo);
-
-                if (!successful)
-                {
-                    _log.LogError($"Unable to put the {args.SourceRepo} into an archive state. Reason: {message}");
-                    return;
-                }
-            }
 
             var migrationId = await githubApi.StartMigration(
                 migrationSourceId,
@@ -296,7 +274,6 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
           string sourceRepo,
           string azureStorageConnectionString,
           string githubSourcePat,
-          bool lockRepo,
           bool noSslVerify = false)
         {
             _log.LogInformation($"GHES API URL: {ghesApiUrl}");
@@ -324,9 +301,9 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
             var ghesApi = noSslVerify ? _sourceGithubApiFactory.CreateClientNoSsl(ghesApiUrl, githubSourcePat) : _sourceGithubApiFactory.Create(ghesApiUrl, githubSourcePat);
             var azureApi = noSslVerify ? _azureApiFactory.CreateClientNoSsl(azureStorageConnectionString) : _azureApiFactory.Create(azureStorageConnectionString);
 
-            var gitDataArchiveId = await ghesApi.StartGitArchiveGeneration(githubSourceOrg, sourceRepo, lockRepo);
+            var gitDataArchiveId = await ghesApi.StartGitArchiveGeneration(githubSourceOrg, sourceRepo);
             _log.LogInformation($"Archive generation of git data started with id: {gitDataArchiveId}");
-            var metadataArchiveId = await ghesApi.StartMetadataArchiveGeneration(githubSourceOrg, sourceRepo, lockRepo);
+            var metadataArchiveId = await ghesApi.StartMetadataArchiveGeneration(githubSourceOrg, sourceRepo);
             _log.LogInformation($"Archive generation of metadata started with id: {metadataArchiveId}");
 
             var timeNow = $"{DateTime.Now:yyyy-MM-dd_HH-mm-ss}";
@@ -499,6 +476,5 @@ namespace OctoshiftCLI.GithubEnterpriseImporter.Commands
         public string GithubSourcePat { get; set; }
         public string GithubTargetPat { get; set; }
         public string AdoPat { get; set; }
-        public bool ArchiveGhRepo { get; set; }
     }
 }


### PR DESCRIPTION
This approach is to allow for the tooling to be consistent with the ADO migration path.

Users can either manually execute the `archive-gh-repo` command with the repo they intent to migration or use the `archive-source-gh-repos` flag when running the `generate-script` command.

The goal is to put the source GHEC or GHES repo into an archived state to ensure users cannot modify any data in the source during it's migration.